### PR TITLE
use explicit ctor for deref ZippedRangeIterator

### DIFF
--- a/include/zipped_range.hpp
+++ b/include/zipped_range.hpp
@@ -30,7 +30,7 @@ public:
         std::tuple<iterator_value_t<std::tuple_element_t<Is, T>>...>;
 
     constexpr reference operator*() const {
-        return { (*std::get<Is>(currents_))... };
+        return reference{ (*std::get<Is>(currents_))... };
     }
 
     constexpr ZippedRangeIterator& operator++() {


### PR DESCRIPTION
Fixes issue with non standard conformant tuple implementations (libstdc+ 4.9 in particular)

Closes #15 